### PR TITLE
Add support for Arch Linux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,14 @@
 class dnsmasq::params {
-  case $::osfamily {
-    debian, redhat, arch: {
+
+  # Facter under ArchLinux reports $osfamily as "Linux", but it
+  # gets $operatingsystem correct.
+  $_family = $osfamily ? {
+    Linux => $operatingsystem,
+    default => $osfamily,
+  }
+
+  case $_family {
+    Debian, RedHat, Archlinux: {
       $package_name = 'dnsmasq'
       $service_name = 'dnsmasq'
       $config_file = '/etc/dnsmasq.conf'


### PR DESCRIPTION
This adds support for Arch Linux:
- File locations are the same as for Redhat and Debian.
- Facter under Arch Linux does not properly populate $osfamily, so there's a small workaround
  for that.
