### PR TITLE
Remove logging from init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,5 @@ class dnsmasq {
   }
 
   anchor { 'dnsmasq::end': require => Class['dnsmasq::service'], }
-  notice("in dnsmasq")
   Common::Line <<| tag == 'dnsmasq-host' |>>
 }


### PR DESCRIPTION
There was an extraneous log line 'in dnsmasq'
that seems to be left over from development.

This commit removes that log.
