### PR TITLE
Replace 'common' dependency with file_line in stdlib

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -13,8 +13,8 @@ define dnsmasq::host (
     $mac_r = inline_template('<%= mac.upcase! %>')
     debug("DNSMASQ: ${h_real} ${ip} ${mac_r}")
 
-    @@common::line { "dnsmasq::ethers ${h_real} ${mac_r}":
-      file   => "/etc/ethers",
+    @@file_line { "dnsmasq::ethers ${h_real} ${mac_r}":
+      path   => "/etc/ethers",
       line   => "${mac_r} ${ip}",
       ensure => $mac ? {
         ''      => 'absent',
@@ -29,7 +29,7 @@ define dnsmasq::host (
     default => " ${aliases}",
   }
 
-  @@common::line { "dnsmasq::hosts ${h_real} ${ip}":
+  @@file_line { "dnsmasq::hosts ${h_real} ${ip}":
     file   => "/etc/hosts",
     line   => "${ip} ${h_real}${al_add}",
     ensure => $ip ? {

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -30,7 +30,7 @@ define dnsmasq::host (
   }
 
   @@file_line { "dnsmasq::hosts ${h_real} ${ip}":
-    file   => "/etc/hosts",
+    path   => "/etc/hosts",
     line   => "${ip} ${h_real}${al_add}",
     ensure => $ip ? {
       ''      => 'absent',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,5 +16,5 @@ class dnsmasq {
   }
 
   anchor { 'dnsmasq::end': require => Class['dnsmasq::service'], }
-  Common::Line <<| tag == 'dnsmasq-host' |>>
+  File_line <<| tag == 'dnsmasq-host' |>>
 }


### PR DESCRIPTION
This addresses #10 

The testing I've done appears to work as expected; the only caveat I can think of is dependent `Common::Line` exported resources in existing installs.