### PR TITLE
Check if storeconfigs is set

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,5 +16,7 @@ class dnsmasq {
   }
 
   anchor { 'dnsmasq::end': require => Class['dnsmasq::service'], }
-  File_line <<| tag == 'dnsmasq-host' |>>
+  if $::settings::storeconfigs {
+    File_line <<| tag == 'dnsmasq-host' |>>
+  }
 }


### PR DESCRIPTION
People using puppet apply without storeconfigs will be unable to use this module without this check in place.