### PR TITLE
Add $dnsmasq::package_ensure

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,8 @@
 class dnsmasq(
   $configs_hash = {},
   $hosts_hash = {},
-  $dhcp_hosts_hash = {}
+  $dhcp_hosts_hash = {},
+  $package_ensure = 'installed',
 ) {
   include ::dnsmasq::params
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,7 @@
 class dnsmasq::install {
-  package { $dnsmasq::params::package_name: ensure => 'installed', }
+  package { $dnsmasq::params::package_name:
+    ensure => $dnsmasq::package_ensure,
+  }
 
   file { $dnsmasq::params::config_dir:
     ensure => 'directory',


### PR DESCRIPTION
I would like to add `$dnsmasq::package_ensure` parameter to control the version of installed dnsmasq package, defaulting to 'installed' (same as the original behaviour).