### PR TITLE
add validate_cmd for config file resources

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -7,11 +7,12 @@ define dnsmasq::conf (
   include dnsmasq
 
   file { "${dnsmasq::params::config_dir}${prio}-${name}":
-    ensure  => $ensure,
-    owner   => 'root',
-    group   => 0,
-    content => $content,
-    source  => $source,
-    notify  => Class['dnsmasq::service'],
+    ensure       => $ensure,
+    owner        => 'root',
+    group        => 0,
+    content      => $content,
+    source       => $source,
+    validate_cmd => '/usr/sbin/dnsmasq --test --conf-file=%',
+    notify       => Class['dnsmasq::service'],
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,8 +1,9 @@
 class dnsmasq::config {
   file { $dnsmasq::params::config_file:
-    owner  => 'root',
-    group  => 0,
-    mode   => '0644',
-    source => 'puppet:///modules/dnsmasq/dnsmasq.conf',
+    owner        => 'root',
+    group        => 0,
+    mode         => '0644',
+    validate_cmd => '/usr/sbin/dnsmasq --test --conf-file=%',
+    source       => 'puppet:///modules/dnsmasq/dnsmasq.conf',
   }
 }


### PR DESCRIPTION
Hi @saz,

this small one here adds the `validate_cmd` parameter to the file resources of dnsmasq config files.
We recently encountered that the module does not verify the files deployed.

Can you test it on your side?
Let me know what you think.

Best
Jard