### PR TITLE
is_string is deprecated.

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,7 +2,7 @@ class dnsmasq::service (
   $service_control = true,
 ) {
   # validate type and convert string to boolean if necessary
-  if is_string($service_control) {
+  if validate_legacy(Boolean, 'is_string', $service_control) {
     $service_control_real = str2bool($service_control)
   } else {
     $service_control_real = $service_control


### PR DESCRIPTION
Now I use validate_legacy function.

Also, It may be good to accept `$service_control` as bool only.