### PR TITLE
Fix deprecation warnings

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,4 +22,5 @@ class dnsmasq::params {
       }
     }
   }
+  $service_control = true
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,11 +1,11 @@
 class dnsmasq::service (
-  $service_control = true,
+  Variant[String, Boolean] $service_control = $dnsmasq::params::service_control,
 ) {
   # validate type and convert string to boolean if necessary
-  if is_string($service_control) {
-    $service_control_real = str2bool($service_control)
-  } else {
-    $service_control_real = $service_control
+  $service_control_real = $service_control ? {
+    Boolean => $service_control,
+    String  => str2bool($service_control),
+    default => fail('Illegal value for $service_control parameter'),
   }
   if $service_control_real == true {
     service { $dnsmasq::params::service_name:


### PR DESCRIPTION
```
Warning: This method is deprecated, please use match expressions with Stdlib::Compat::String instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions. at ["/etc/puppetlabs/code/environments/production/modules/dnsmasq/manifests/service.pp", 5]:["/etc/puppetlabs/code/environments/production/modules/profile/manifests/dnsmasq.pp", 2]
   (location: /etc/puppetlabs/code/environments/production/modules/stdlib/lib/puppet/functions/deprecation.rb:28:in `deprecation')
```

Seen on Puppet 5.5.16, tested on 5.5 and 6.x