### PR TITLE
Allow stdlib v8.x to be used

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,6 @@
     }
   ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.0.0 < 8.0.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.0.0 < 9.0.0" }
   ]
 }


### PR DESCRIPTION
puppetlabs/stdlib 8.1.0 has been released in October 2021. This PR allows it.

The only reason why `stdlib` is used at all (as far as I can tell) is this one:

https://github.com/saz/puppet-dnsmasq/blob/b04a4742952fadff11ca625887917481f7b8bbb1/manifests/service.pp#L6

If you see how we could get rid of this, we could drop the dependency altogether.