### PR TITLE
[service] More precise service control

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,10 +1,12 @@
 class dnsmasq (
-  Hash    $configs_hash     = {},
-  Hash    $hosts_hash       = {},
-  Hash    $dhcp_hosts_hash  = {},
-  String  $package_ensure   = 'installed',
-  Boolean $service_control  = true,
-  Boolean $purge_config_dir = false,
+  Hash                       $configs_hash     = {},
+  Hash                       $hosts_hash       = {},
+  Hash                       $dhcp_hosts_hash  = {},
+  String                     $package_ensure   = 'installed',
+  Boolean                    $service_control  = true,
+  Enum['running', 'stopped'] $service_ensure   = 'running',
+  Boolean                    $service_enable   = true,
+  Boolean                    $purge_config_dir = false,
 ) {
   include dnsmasq::params
 
@@ -14,6 +16,8 @@ class dnsmasq (
 
   class { 'dnsmasq::service':
     service_control => $service_control,
+    service_ensure  => $service_ensure,
+    service_enable  => $server_enable,
     subscribe       => Class['dnsmasq::install', 'dnsmasq::config'],
   }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,5 +1,7 @@
 class dnsmasq::service (
-  Variant[String, Boolean] $service_control = $dnsmasq::params::service_control,
+  Variant[String, Boolean]   $service_control = $dnsmasq::params::service_control,
+  Enum['running', 'stopped'] $service_ensure  = 'running',
+  Boolean                    $service_enable  = true,
 ) {
   # validate type and convert string to boolean if necessary
   if $service_control =~ String {
@@ -9,8 +11,8 @@ class dnsmasq::service (
   }
   if $service_control_real == true {
     service { $dnsmasq::params::service_name:
-      ensure     => 'running',
-      enable     => true,
+      ensure     => $service_ensure,
+      enable     => $service_enable,
       hasrestart => true,
       hasstatus  => true,
     }


### PR DESCRIPTION
Hello!
This small patch add more precise service control (service_ensure and service_enable flags) when service controlled by this module.
Administrator can change that some servers is running and enabled and some servers are not.
This helpful for migration processes or when you need to do some logic, related on other stuff
**Default behavior not changed.**